### PR TITLE
feat: build for alpine host

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           make -s -j`nproc`
           make -s install
+          cat README.md | awk '{gsub(/\[[^][]+\]\([^()]+\)/, gensub(/\[([^][]+)\]\([^()]+\)/, "\\1", "g")); print}' | fmt -w 72 > /opt/musl-dyne/README.txt
           echo "Compressing:  musl-dyne-${{ matrix.output }}.tar.xz"
           cd /opt && tar -cJf musl-dyne-${{ matrix.output }}.tar.xz musl-dyne
       - name: Upload release artifacts musl-dyne-${{ matrix.output }}
@@ -85,9 +86,60 @@ jobs:
           path: |
             /opt/musl-dyne-${{ matrix.output }}.tar.xz
 
+  alpine-release:
+    name: 🗻 Alpine build
+    runs-on: ubuntu-latest
+    needs: [semantic-release]
+    if: ${{ needs.semantic-release.outputs.new_release_published == 'true' }}
+    strategy:
+      matrix:
+        include:
+          - target: arm-linux-musleabihf
+            output: arm_hf
+          - target: riscv64-linux-musl
+            output: riscv_64
+          - target: aarch64-linux-musl
+            output: arm_64
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup latest Alpine Linux
+        uses: jirutka/setup-alpine@v1
+      - name: Install build deps in Alpine chroot
+        run: |
+          cat /etc/alpine-release
+          apk add  bash make gcc build-base curl patch gawk ccache perl rsync
+        shell: alpine.sh --root {0}
+      - name: Download sources inside Alpine chroot
+        run: |
+          ls -la
+          cd sources && sh download_from_dyne.sh
+        shell: alpine.sh {0}
+      - name: Build musl-dyne inside Alpine chroot
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          make -j`nproc`
+        shell: alpine.sh {0}
+      - name: Install on the host system (Ubuntu)
+        env:
+          XZ_OPT: -9e -T0
+          TARGET: ${{ matrix.target }}
+        run: |
+          cat /etc/os-release
+          sudo make install
+          echo "Compressing:  cross-alpine-${{ matrix.output }}.tar.xz"
+          cd /opt && tar -cJf cross-alpine-${{ matrix.output }}.tar.xz musl-dyne
+        shell: bash
+      - name: Upload release artifacts cross-alpine-${{ matrix.output }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpine-${{ matrix.output }}
+          path: |
+            /opt/cross-alpine-${{ matrix.output }}.tar.xz
+
   draft-binary-release:
     name: 📦 Pack release
-    needs: [semantic-release, linux-release]
+    needs: [semantic-release, linux-release, alpine-release]
     runs-on: ubuntu-latest
     steps:
       - name: download binary artifacts
@@ -115,6 +167,9 @@ jobs:
             musl-dyne/release-arm_hf/musl-dyne-arm_hf.tar.xz,
             musl-dyne/release-arm_64/musl-dyne-arm_64.tar.xz,
             musl-dyne/release-riscv_64/musl-dyne-riscv_64.tar.xz,
+            musl-dyne/alpine-arm_hf/cross-alpine-arm_hf.tar.xz,
+            musl-dyne/alpine-arm_64/cross-alpine-arm_64.tar.xz,
+            musl-dyne/alpine-riscv_64/cross-alpine-riscv_64.tar.xz,
             musl-dyne/checksums/SHA256SUMS.txt
           target: |
             /srv/ftp/musl
@@ -125,6 +180,7 @@ jobs:
         with:
           files: |
             musl-dyne/release-*/*
+            musl-dyne/alpine-*/*
             musl-dyne/checksums/SHA256SUMS.txt
           tag_name: ${{ needs.semantic-release.outputs.new_release_version }}
           #body_path: musl-dyne/documentation/release-intro.md


### PR DESCRIPTION
distribute cross chains for alpine hosts as it seems they don't exist yet.

Thanks to David Sugar for his feedback about it:
> Alpine can be made to produce static binaries, but it's cross-compile support never was formally extended to arbitrary user space outside of bootstrap. So, if I want to build arbitrary user mode applications for Arm, I could locally do a arm build on a pi or on qemu user mode, but both are tortuously slow. I saw this as potentially filling a particular gap.

In this case, knowing what gap to fill was already half of the job :^)